### PR TITLE
Handle unsupported OS detection fallback

### DIFF
--- a/openccjni/src/main/java/openccjni/NativeLibLoader.java
+++ b/openccjni/src/main/java/openccjni/NativeLibLoader.java
@@ -264,8 +264,8 @@ public final class NativeLibLoader {
     static String detectOs() {
         if (isWindows()) return "windows";
         if (isMac()) return "macos";
-//        if (isLinux()) return "linux";
-        return "linux"; // conservative default
+        if (isLinux()) return "linux";
+        return "unknown"; // unsupported OS
     }
 
     static String detectArch() {


### PR DESCRIPTION
## Summary
- Add Linux check back into `detectOs`
- Return `unknown` for unsupported operating systems

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit:junit-bom:5.10.0, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a711f6d0832cb6118cc8d55d1617