### PR TITLE
Use LOGGER for zipping and cleanup errors

### DIFF
--- a/openccjni/src/main/java/openccjni/OfficeHelper.java
+++ b/openccjni/src/main/java/openccjni/OfficeHelper.java
@@ -270,7 +270,7 @@ public class OfficeHelper {
                                     Files.copy(path, zos);
                                     zos.closeEntry();
                                 } catch (IOException e) {
-                                    System.err.println("Error zipping file " + path + ": " + e.getMessage());
+                                    LOGGER.log(Level.WARNING, "Error zipping file " + path, e);
                                 }
                             });
                 }
@@ -456,7 +456,7 @@ public class OfficeHelper {
      * <p>This method is typically used to clean up temporary extraction folders after document processing.
      * It walks the file tree in reverse order (files first, then directories) to ensure successful deletion.
      *
-     * <p>Any deletion failures (e.g. due to file locks) are logged to {@code System.err}, but do not halt execution.
+     * <p>Any deletion failures (e.g. due to file locks) are logged but do not halt execution.
      *
      * @param dirPath the root directory to delete
      */
@@ -471,12 +471,12 @@ public class OfficeHelper {
                             try {
                                 Files.delete(p);
                             } catch (IOException e) {
-                                System.err.println("⚠️ Failed to delete " + p + ": " + e.getMessage());
+                                LOGGER.log(Level.WARNING, "Failed to delete " + p, e);
                             }
                         });
             }
         } catch (IOException e) {
-            System.err.println("Error walking directory for cleanup at " + dirPath + ": " + e.getMessage());
+            LOGGER.log(Level.WARNING, "Error walking directory for cleanup at " + dirPath, e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace `System.err.println` in `zip` with `LOGGER.log`
- Replace `System.err.println` in `deleteRecursive` with `LOGGER.log` and update documentation

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.3 (status code 403))*

------
https://chatgpt.com/codex/tasks/task_e_68b71cd14a6c832c89e9972b2b89566a