### PR TITLE
Use thread-local last error

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ OpenCC.getSupportedConfigs() -> List<String>
 
 // Last error message
 OpenCC.getLastError() -> String
+OpenCC.setLastError(String err)
 
 ```
 
@@ -303,9 +304,6 @@ cc.convert(String input, boolean punctuation)
 cc.getConfig() -> String
 cc.setConfig(String config)
 
-// Error handling
-cc.getLastError() -> String
-cc.setLastError(String err)
 
 ```
 

--- a/openccjni/src/main/java/openccjni/OpenCC.java
+++ b/openccjni/src/main/java/openccjni/OpenCC.java
@@ -74,7 +74,7 @@ public final class OpenCC {
     /**
      * Last error message encountered by OpenCC operations.
      */
-    private static String lastError;
+    private static final ThreadLocal<String> LAST_ERROR = new ThreadLocal<>();
 
     // ---------- Static helpers ----------
 
@@ -102,7 +102,7 @@ public final class OpenCC {
      */
     public static String convert(String input, String config) {
         if (!CONFIG_SET.contains(config)) {
-            lastError = "Invalid config: " + config;
+            setLastError("Invalid config: " + config);
             return input;
         }
         return WRAPPER.get().convert(input, config, false);
@@ -120,7 +120,7 @@ public final class OpenCC {
      */
     public static String convert(String input, String config, boolean punctuation) {
         if (!CONFIG_SET.contains(config)) {
-            lastError = "Invalid config: " + config;
+            setLastError("Invalid config: " + config);
             return input;
         }
         return WRAPPER.get().convert(input, config, punctuation);
@@ -240,10 +240,11 @@ public final class OpenCC {
      *
      * @return error message, or empty string if none
      */
-    public String getLastError() {
+    public static String getLastError() {
         String nativeErr = WRAPPER.get().getLastError();
         if (nativeErr != null && !nativeErr.isEmpty()) return nativeErr;
-        return lastError != null ? lastError : "";
+        String err = LAST_ERROR.get();
+        return err != null ? err : "";
     }
 
     /**
@@ -253,7 +254,7 @@ public final class OpenCC {
      * @param lastError the error message to record (maybe {@code null})
      * @since 1.0.0
      */
-    public void setLastError(String lastError) {
-        OpenCC.lastError = lastError;
+    public static void setLastError(String lastError) {
+        LAST_ERROR.set(lastError);
     }
 }

--- a/openccjni/src/test/java/openccjni/OpenCCTests.java
+++ b/openccjni/src/test/java/openccjni/OpenCCTests.java
@@ -101,7 +101,7 @@ public class OpenCCTests {
         OpenCC bad = new OpenCC("invalid_config");
         assertEquals("s2t", bad.getConfig());
         assertEquals("測試", bad.convert("测试"));
-        assertNotNull(bad.getLastError());
-        System.out.println("Last Error: " + bad.getLastError());
+        assertNotNull(OpenCC.getLastError());
+        System.out.println("Last Error: " + OpenCC.getLastError());
     }
 }


### PR DESCRIPTION
## Summary
- Track last error per thread with `ThreadLocal`
- Expose static `getLastError`/`setLastError` and update conversion helpers
- Adapt tests and docs to use the new static API

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.3 - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b720f9dd78832ca0038b2d26e2337b