### PR TITLE
Log native library loading failures

### DIFF
--- a/openccjni/src/main/java/openccjni/NativeLibLoader.java
+++ b/openccjni/src/main/java/openccjni/NativeLibLoader.java
@@ -109,6 +109,7 @@ public final class NativeLibLoader {
                     // optional: skip if missing/unavailable
                     continue;
                 }
+                System.err.println("Failed to extract native '" + p.base + "': " + e);
                 throw new UnsatisfiedLinkError("Failed to extract native '" + p.base + "': " + e);
             }
         }
@@ -131,6 +132,7 @@ public final class NativeLibLoader {
                     System.load(p.extractedPath.toAbsolutePath().toString());
                 } catch (Throwable t) {
                     LOADED.remove(key); // rollback the optimistic mark
+                    System.err.println("Failed to load native '" + p.base + "' from " + p.extractedPath + ": " + t);
                     throw t;
                 }
             }
@@ -144,6 +146,7 @@ public final class NativeLibLoader {
             System.loadLibrary(baseName);
             return true;
         } catch (UnsatisfiedLinkError e) {
+            System.err.println("System.loadLibrary(\"" + baseName + "\") failed: " + e);
             return false;
         }
     }

--- a/openccjni/src/main/java/openccjni/OpenCC.java
+++ b/openccjni/src/main/java/openccjni/OpenCC.java
@@ -44,7 +44,8 @@ public final class OpenCC {
             // 1) Try normal search path (PATH, java.library.path, working dir, etc.)
             System.loadLibrary("OpenccWrapper");
         } catch (UnsatisfiedLinkError e) {
-            // 2) Fallback: extract from JAR resources and load dependencies in order
+            // Log and fallback to resources packaged in the JAR
+            System.err.println("Failed to load 'OpenccWrapper' via System.loadLibrary: " + e);
             NativeLibLoader.loadChain(
                     "opencc_fmmseg_capi",
                     "OpenccWrapper"


### PR DESCRIPTION
## Summary
- Log and fallback when `OpenccWrapper` system load fails.
- Emit diagnostic messages for extraction and load failures in `NativeLibLoader`.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b726ac0278832ca09b8c5310e694d4