### PR TITLE
Handle null inputs in convert methods

### DIFF
--- a/openccjni/src/main/java/openccjni/OpenCC.java
+++ b/openccjni/src/main/java/openccjni/OpenCC.java
@@ -107,6 +107,10 @@ public final class OpenCC {
      * @since 1.0.0
      */
     public static String convert(String input, String config) {
+        if (input == null) {
+            setLastError("Input is null");
+            return null;
+        }
         if (!CONFIG_SET.contains(config)) {
             setLastError("Invalid config: " + config);
             return input;
@@ -127,6 +131,10 @@ public final class OpenCC {
      * @since 1.0.0
      */
     public static String convert(String input, String config, boolean punctuation) {
+        if (input == null) {
+            setLastError("Input is null");
+            return null;
+        }
         if (!CONFIG_SET.contains(config)) {
             setLastError("Invalid config: " + config);
             return input;
@@ -197,6 +205,10 @@ public final class OpenCC {
      * @since 1.0.0
      */
     public String convert(String input) {
+        if (input == null) {
+            setLastError("Input is null");
+            return null;
+        }
         // Clear any previous Java-side error before invoking the native layer
         setLastError(null);
         return WRAPPER.get().convert(input, this.config, false);
@@ -212,6 +224,10 @@ public final class OpenCC {
      * @since 1.0.0
      */
     public String convert(String input, boolean punctuation) {
+        if (input == null) {
+            setLastError("Input is null");
+            return null;
+        }
         // Clear any previous Java-side error before invoking the native layer
         setLastError(null);
         return WRAPPER.get().convert(input, this.config, punctuation);
@@ -253,15 +269,15 @@ public final class OpenCC {
     }
 
     /**
-     * Returns the last error message (native error has priority; otherwise the Java-side error).
+     * Returns the last error message (Java-side error has priority; otherwise the native error).
      *
      * @return error message, or empty string if none
      */
     public static String getLastError() {
-        String nativeErr = WRAPPER.get().getLastError();
-        if (nativeErr != null && !nativeErr.isEmpty()) return nativeErr;
         String err = LAST_ERROR.get();
-        return err != null ? err : "";
+        if (err != null && !err.isEmpty()) return err;
+        String nativeErr = WRAPPER.get().getLastError();
+        return nativeErr != null ? nativeErr : "";
     }
 
     /**

--- a/openccjni/src/test/java/openccjni/OpenCCTests.java
+++ b/openccjni/src/test/java/openccjni/OpenCCTests.java
@@ -51,6 +51,28 @@ public class OpenCCTests {
     }
 
     @Test
+    void testNullInputStaticConvert() {
+        OpenCC.setLastError(null);
+        assertNull(OpenCC.convert(null, "s2t"));
+        assertEquals("Input is null", OpenCC.getLastError());
+
+        OpenCC.setLastError(null);
+        assertNull(OpenCC.convert(null, "s2t", true));
+        assertEquals("Input is null", OpenCC.getLastError());
+    }
+
+    @Test
+    void testNullInputInstanceConvert() {
+        OpenCC.setLastError(null);
+        assertNull(opencc1.convert(null));
+        assertEquals("Input is null", OpenCC.getLastError());
+
+        OpenCC.setLastError(null);
+        assertNull(opencc1.convert(null, true));
+        assertEquals("Input is null", OpenCC.getLastError());
+    }
+
+    @Test
     void testZhoCheckTraditional() {
         String text = "繁體中文";
         int result = OpenCC.zhoCheck(text);


### PR DESCRIPTION
## Summary
- Prevent null pointer issues in `OpenCC.convert` by returning null and recording a clear error message when input is null.
- Make `getLastError` favor Java-side errors over native messages.
- Add unit tests covering null-input scenarios for static and instance conversions.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b728450bb4832c8f949f6b08bfb318