### PR TITLE
refactor: simplify native wrapper config handling

### DIFF
--- a/openccjni/src/main/java/openccjni/OpenccWrapper.java
+++ b/openccjni/src/main/java/openccjni/OpenccWrapper.java
@@ -1,11 +1,6 @@
 package openccjni;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -85,26 +80,7 @@ public class OpenccWrapper implements AutoCloseable {
      */
     private long instance;
 
-    /**
-     * List of supported configuration names (conversion profiles).
-     */
-    private static final List<String> configList = Arrays.asList(
-            "s2t", "t2s", "s2tw", "tw2s", "s2twp", "tw2sp", "s2hk", "hk2s",
-            "t2tw", "t2twp", "t2hk", "tw2t", "tw2tp", "hk2t", "t2jp", "jp2t"
-    );
-
-    /**
-     * Precomputed UTF-8 bytes for each supported config.
-     */
-    private static final Map<String, byte[]> CONFIG_BYTES;
-
-    static {
-        Map<String, byte[]> map = new HashMap<>();
-        for (String cfg : configList) {
-            map.put(cfg, cfg.getBytes(StandardCharsets.UTF_8));
-        }
-        CONFIG_BYTES = Collections.unmodifiableMap(map);
-    }
+    // No configuration list; higher-level classes should validate configs.
 
     // ------------------------------------------------------------------------
     // Constructors
@@ -146,7 +122,7 @@ public class OpenccWrapper implements AutoCloseable {
      * Converts the given input string using a specified configuration.
      *
      * @param input       input text
-     * @param config      conversion config key (if invalid, defaults to "s2t")
+     * @param config      conversion config key
      * @param punctuation whether to convert punctuation as well
      * @return the converted string
      * @throws RuntimeException if conversion fails
@@ -159,10 +135,7 @@ public class OpenccWrapper implements AutoCloseable {
         if (input.isEmpty()) return "";
 
         byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
-        byte[] configBytes = CONFIG_BYTES.get(config);
-        if (configBytes == null) {
-            configBytes = CONFIG_BYTES.get("s2t");
-        }
+        byte[] configBytes = config.getBytes(StandardCharsets.UTF_8);
         byte[] rawOutput = opencc_convert(instance, inputBytes, configBytes, punctuation);
 
         if (rawOutput == null) {


### PR DESCRIPTION
## Summary
- remove internal configuration list from `OpenccWrapper` and rely on higher-level `OpenCC` to validate configs
- simplify `convert` to require a non-null config and delegate invalid-config errors to the native layer

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b73a118528832c82b488e4c695b0aa